### PR TITLE
refactor(core): add toImmutable()/toMutable() extension functions on Vector interfaces

### DIFF
--- a/src/commonMain/kotlin/io/github/cponfick/kompgeom/core/VectorExtensions.kt
+++ b/src/commonMain/kotlin/io/github/cponfick/kompgeom/core/VectorExtensions.kt
@@ -1,0 +1,74 @@
+package io.github.cponfick.kompgeom.core
+
+import io.github.cponfick.kompgeom.euclidean.oned.MutableVec1
+import io.github.cponfick.kompgeom.euclidean.oned.Vec1
+import io.github.cponfick.kompgeom.euclidean.threed.MutableVec3
+import io.github.cponfick.kompgeom.euclidean.threed.Vec3
+import io.github.cponfick.kompgeom.euclidean.twod.MutableVec2
+import io.github.cponfick.kompgeom.euclidean.twod.Vec2
+
+/**
+ * Returns this vector as an immutable [Vec1].
+ *
+ * If this vector is already a [Vec1], it is returned directly without copying.
+ *
+ * @return An immutable [Vec1] with the same component as this vector.
+ */
+public fun Vector1<*>.toImmutable(): Vec1 =
+  when (this) {
+    is Vec1 -> this
+    else -> Vec1(x)
+  }
+
+/**
+ * Returns a mutable copy of this vector as a [MutableVec1].
+ *
+ * Always creates a new instance, even if this vector is already a [MutableVec1].
+ *
+ * @return A new [MutableVec1] with the same component as this vector.
+ */
+public fun Vector1<*>.toMutable(): MutableVec1 = MutableVec1(x)
+
+/**
+ * Returns this vector as an immutable [Vec2].
+ *
+ * If this vector is already a [Vec2], it is returned directly without copying.
+ *
+ * @return An immutable [Vec2] with the same components as this vector.
+ */
+public fun Vector2<*>.toImmutable(): Vec2 =
+  when (this) {
+    is Vec2 -> this
+    else -> Vec2(x, y)
+  }
+
+/**
+ * Returns a mutable copy of this vector as a [MutableVec2].
+ *
+ * Always creates a new instance, even if this vector is already a [MutableVec2].
+ *
+ * @return A new [MutableVec2] with the same components as this vector.
+ */
+public fun Vector2<*>.toMutable(): MutableVec2 = MutableVec2(x, y)
+
+/**
+ * Returns this vector as an immutable [Vec3].
+ *
+ * If this vector is already a [Vec3], it is returned directly without copying.
+ *
+ * @return An immutable [Vec3] with the same components as this vector.
+ */
+public fun Vector3<*>.toImmutable(): Vec3 =
+  when (this) {
+    is Vec3 -> this
+    else -> Vec3(x, y, z)
+  }
+
+/**
+ * Returns a mutable copy of this vector as a [MutableVec3].
+ *
+ * Always creates a new instance, even if this vector is already a [MutableVec3].
+ *
+ * @return A new [MutableVec3] with the same components as this vector.
+ */
+public fun Vector3<*>.toMutable(): MutableVec3 = MutableVec3(x, y, z)

--- a/src/commonMain/kotlin/io/github/cponfick/kompgeom/euclidean/oned/MutableVec1.kt
+++ b/src/commonMain/kotlin/io/github/cponfick/kompgeom/euclidean/oned/MutableVec1.kt
@@ -22,20 +22,6 @@ public class MutableVec1(public override var x: Double) : Vector1<MutableVec1> {
 
   override fun toString(): String = "MutableVec1(x=$x)"
 
-  /**
-   * Creates an immutable copy of this vector.
-   *
-   * @return An immutable [Vec1] with the same component as this vector.
-   */
-  public fun toVec1(): Vec1 = Vec1(x)
-
-  /**
-   * Creates a mutable copy of this vector.
-   *
-   * @return A mutable [MutableVec1] with the same component as this mutable vector.
-   */
-  public fun toMutableVec1(): MutableVec1 = MutableVec1(x)
-
   public companion object {
     /**
      * Create a zero vector.

--- a/src/commonMain/kotlin/io/github/cponfick/kompgeom/euclidean/oned/Vec1.kt
+++ b/src/commonMain/kotlin/io/github/cponfick/kompgeom/euclidean/oned/Vec1.kt
@@ -21,20 +21,6 @@ public data class Vec1(public override val x: Double) : Vector1<Vec1> {
 
   override fun withComponents(x: Double): Vec1 = Vec1(x)
 
-  /**
-   * Creates an immutable copy of this vector.
-   *
-   * @return An immutable [Vec1] with the same component as this vector.
-   */
-  public fun toVec1(): Vec1 = Vec1(x)
-
-  /**
-   * Creates a mutable copy of this vector.
-   *
-   * @return A mutable [MutableVec1] with the same component as this mutable vector.
-   */
-  public fun toMutableVec1(): MutableVec1 = MutableVec1(x)
-
   public companion object {
     /** The zero vector. */
     public val ZERO: Vec1 = Vec1(0.0)

--- a/src/commonMain/kotlin/io/github/cponfick/kompgeom/euclidean/threed/MutableVec3.kt
+++ b/src/commonMain/kotlin/io/github/cponfick/kompgeom/euclidean/threed/MutableVec3.kt
@@ -61,20 +61,6 @@ public class MutableVec3(
 
   override fun zero(): MutableVec3 = MutableVec3(0.0, 0.0, 0.0)
 
-  /**
-   * Converts this mutable vector to an immutable [Vec3].
-   *
-   * @return An immutable [Vec3] with the same components as this mutable vector.
-   */
-  public fun toVec3(): Vec3 = Vec3(x, y, z)
-
-  /**
-   * Creates a mutable copy of this vector.
-   *
-   * @return A new [MutableVec3] instance with the same components as this vector.
-   */
-  public fun toMutableVec3(): MutableVec3 = MutableVec3(x, y, z)
-
   public override fun toString(): String = "MutableVec3(x=$x, y=$y, z=$z)"
 
   public companion object {

--- a/src/commonMain/kotlin/io/github/cponfick/kompgeom/euclidean/threed/Vec3.kt
+++ b/src/commonMain/kotlin/io/github/cponfick/kompgeom/euclidean/threed/Vec3.kt
@@ -36,20 +36,6 @@ public data class Vec3(
 
   override fun withComponents(x: Double, y: Double, z: Double): Vec3 = Vec3(x, y, z)
 
-  /**
-   * Creates an immutable copy of this vector.
-   *
-   * @return An immutable [Vec3] with the same components as this vector.
-   */
-  public fun toVec3(): Vec3 = Vec3(x, y, z)
-
-  /**
-   * Creates a mutable copy of this vector.
-   *
-   * @return A mutable [MutableVec3] with the same components as this immutable vector.
-   */
-  public fun toMutableVec3(): MutableVec3 = MutableVec3(x, y, z)
-
   public companion object {
     /** The zero vector. */
     public val ZERO: Vec3 = Vec3(0.0, 0.0, 0.0)

--- a/src/commonMain/kotlin/io/github/cponfick/kompgeom/euclidean/twod/MutableVec2.kt
+++ b/src/commonMain/kotlin/io/github/cponfick/kompgeom/euclidean/twod/MutableVec2.kt
@@ -36,20 +36,6 @@ public class MutableVec2(public override var x: Double, public override var y: D
 
   override fun zero(): MutableVec2 = MutableVec2(0.0, 0.0)
 
-  /**
-   * Creates an immutable copy of this vector.
-   *
-   * @return An immutable [Vec2] with the same components as this vector.
-   */
-  public fun toVec2(): Vec2 = Vec2(x, y)
-
-  /**
-   * Creates a mutable copy of this vector.
-   *
-   * @return A mutable [MutableVec2] with the same components as this mutable vector.
-   */
-  public fun toMutableVec2(): MutableVec2 = MutableVec2(x, y)
-
   public override fun toString(): String = "MutableVec2(x=$x, y=$y)"
 
   public companion object {

--- a/src/commonMain/kotlin/io/github/cponfick/kompgeom/euclidean/twod/Vec2.kt
+++ b/src/commonMain/kotlin/io/github/cponfick/kompgeom/euclidean/twod/Vec2.kt
@@ -23,20 +23,6 @@ public data class Vec2(public override val x: Double, public override val y: Dou
 
   override fun withComponents(x: Double, y: Double): Vec2 = Vec2(x, y)
 
-  /**
-   * Creates an immutable copy of this vector.
-   *
-   * @return An immutable [Vec2] with the same components as this vector.
-   */
-  public fun toVec2(): Vec2 = Vec2(x, y)
-
-  /**
-   * Creates a mutable copy of this vector.
-   *
-   * @return A mutable [MutableVec2] with the same components as this mutable vector.
-   */
-  public fun toMutableVec2(): MutableVec2 = MutableVec2(x, y)
-
   public companion object {
     /** The zero vector. */
     public val ZERO: Vec2 = Vec2(0.0, 0.0)

--- a/src/commonTest/kotlin/io/github/cponfick/kompgeom/algorithms/closestpair/ClosestPairDivideAndConquerTest.kt
+++ b/src/commonTest/kotlin/io/github/cponfick/kompgeom/algorithms/closestpair/ClosestPairDivideAndConquerTest.kt
@@ -1,5 +1,6 @@
 package io.github.cponfick.kompgeom.algorithms.closestpair
 
+import io.github.cponfick.kompgeom.core.toMutable
 import io.github.cponfick.kompgeom.euclidean.twod.Vec2
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
@@ -66,7 +67,7 @@ class ClosestPairDivideAndConquerTest {
 
   @Test
   fun `calculates the closest pair of points mutable input`() {
-    val mutablePoints = manyPoints.map { it.toMutableVec2() }
+    val mutablePoints = manyPoints.map { it.toMutable() }
     val closestPairNaiveResult = ClosestPairNaive(mutablePoints).execute()
     val actual = ClosestPairDivideAndConquer(mutablePoints).execute()
 

--- a/src/commonTest/kotlin/io/github/cponfick/kompgeom/algorithms/convexhull/Quickhull2Test.kt
+++ b/src/commonTest/kotlin/io/github/cponfick/kompgeom/algorithms/convexhull/Quickhull2Test.kt
@@ -1,5 +1,6 @@
 package io.github.cponfick.kompgeom.algorithms.convexhull
 
+import io.github.cponfick.kompgeom.core.toMutable
 import io.github.cponfick.kompgeom.euclidean.twod.Vec2
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
@@ -107,8 +108,8 @@ class Quickhull2Test {
 
   @Test
   fun `execute hull with internal points mutable input`() {
-    val mutableHull = hull.map { it.toMutableVec2() }
-    val mutableInternalPoints = internalPoints.map { it.toMutableVec2() }
+    val mutableHull = hull.map { it.toMutable() }
+    val mutableInternalPoints = internalPoints.map { it.toMutable() }
 
     val result = Quickhull2(mutableHull + mutableInternalPoints).execute()
     result.points.size shouldBe 15

--- a/src/commonTest/kotlin/io/github/cponfick/kompgeom/core/VectorExtensionsTest.kt
+++ b/src/commonTest/kotlin/io/github/cponfick/kompgeom/core/VectorExtensionsTest.kt
@@ -1,0 +1,108 @@
+package io.github.cponfick.kompgeom.core
+
+import io.github.cponfick.kompgeom.euclidean.oned.MutableVec1
+import io.github.cponfick.kompgeom.euclidean.oned.Vec1
+import io.github.cponfick.kompgeom.euclidean.threed.MutableVec3
+import io.github.cponfick.kompgeom.euclidean.threed.Vec3
+import io.github.cponfick.kompgeom.euclidean.twod.MutableVec2
+import io.github.cponfick.kompgeom.euclidean.twod.Vec2
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import kotlin.test.Test
+
+class VectorExtensionsTest {
+
+  @Test
+  fun `toImmutable on Vec1 returns same instance`() {
+    val vec = Vec1(1.0)
+    val result = vec.toImmutable()
+    result shouldBeSameInstanceAs vec
+  }
+
+  @Test
+  fun `toImmutable on MutableVec1 returns Vec1 with same component`() {
+    val mutable = MutableVec1(2.5)
+    val result = mutable.toImmutable()
+    result.x shouldBe 2.5
+  }
+
+  @Test
+  fun `toMutable on Vec1 returns new MutableVec1 with same component`() {
+    val vec = Vec1(3.0)
+    val result = vec.toMutable()
+    result.x shouldBe 3.0
+  }
+
+  @Test
+  fun `toMutable on MutableVec1 returns a new instance`() {
+    val mutable = MutableVec1(4.0)
+    val result = mutable.toMutable()
+    result.eq(mutable) shouldBe true
+    result shouldNotBe mutable
+  }
+
+  @Test
+  fun `toImmutable on Vec2 returns same instance`() {
+    val vec = Vec2(1.0, 2.0)
+    val result = vec.toImmutable()
+    result shouldBeSameInstanceAs vec
+  }
+
+  @Test
+  fun `toImmutable on MutableVec2 returns Vec2 with same components`() {
+    val mutable = MutableVec2(3.0, 4.0)
+    val result = mutable.toImmutable()
+    result.x shouldBe 3.0
+    result.y shouldBe 4.0
+  }
+
+  @Test
+  fun `toMutable on Vec2 returns new MutableVec2 with same components`() {
+    val vec = Vec2(5.0, 6.0)
+    val result = vec.toMutable()
+    result.x shouldBe 5.0
+    result.y shouldBe 6.0
+  }
+
+  @Test
+  fun `toMutable on MutableVec2 returns a new instance`() {
+    val mutable = MutableVec2(7.0, 8.0)
+    val result = mutable.toMutable()
+    result.eq(mutable) shouldBe true
+    result shouldNotBe mutable
+  }
+
+  @Test
+  fun `toImmutable on Vec3 returns same instance`() {
+    val vec = Vec3(1.0, 2.0, 3.0)
+    val result = vec.toImmutable()
+    result shouldBeSameInstanceAs vec
+  }
+
+  @Test
+  fun `toImmutable on MutableVec3 returns Vec3 with same components`() {
+    val mutable = MutableVec3(4.0, 5.0, 6.0)
+    val result = mutable.toImmutable()
+    result.x shouldBe 4.0
+    result.y shouldBe 5.0
+    result.z shouldBe 6.0
+  }
+
+  @Test
+  fun `toMutable on Vec3 returns new MutableVec3 with same components`() {
+    val vec = Vec3(7.0, 8.0, 9.0)
+    val result = vec.toMutable()
+    result.x shouldBe 7.0
+    result.y shouldBe 8.0
+    result.z shouldBe 9.0
+  }
+
+  @Test
+  fun `toMutable on MutableVec3 returns a new instance`() {
+    val mutable = MutableVec3(10.0, 11.0, 12.0)
+    val result = mutable.toMutable()
+    result.eq(mutable) shouldBe true
+    result shouldNotBe mutable
+  }
+}

--- a/src/commonTest/kotlin/io/github/cponfick/kompgeom/euclidean/oned/MutableVec1Test.kt
+++ b/src/commonTest/kotlin/io/github/cponfick/kompgeom/euclidean/oned/MutableVec1Test.kt
@@ -1,6 +1,8 @@
 package io.github.cponfick.kompgeom.euclidean.oned
 
 import io.github.cponfick.kompgeom.core.AngleUnit
+import io.github.cponfick.kompgeom.core.toImmutable
+import io.github.cponfick.kompgeom.core.toMutable
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -217,16 +219,16 @@ class MutableVec1Test {
   }
 
   @Test
-  fun `toVec1 returns correct Vec1`() {
+  fun `toImmutable returns correct Vec1`() {
     val mutableVec = MutableVec1(4.2)
-    val vec = mutableVec.toVec1()
+    val vec = mutableVec.toImmutable()
     vec.x shouldBe 4.2
   }
 
   @Test
-  fun `toMutableVec1 returns new MutableVec1`() {
+  fun `toMutable returns new MutableVec1`() {
     val mutableVec = MutableVec1(5.3)
-    val result = mutableVec.toMutableVec1()
+    val result = mutableVec.toMutable()
     result.eq(mutableVec) shouldBe true
     result shouldNotBe mutableVec
   }

--- a/src/commonTest/kotlin/io/github/cponfick/kompgeom/euclidean/oned/Vec1Test.kt
+++ b/src/commonTest/kotlin/io/github/cponfick/kompgeom/euclidean/oned/Vec1Test.kt
@@ -1,6 +1,8 @@
 package io.github.cponfick.kompgeom.euclidean.oned
 
 import io.github.cponfick.kompgeom.core.AngleUnit
+import io.github.cponfick.kompgeom.core.toImmutable
+import io.github.cponfick.kompgeom.core.toMutable
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlin.math.PI
@@ -217,17 +219,18 @@ class Vec1Test {
   }
 
   @Test
-  fun `toMutableVec1 returns correct MutableVec1`() {
+  fun `toMutable returns correct MutableVec1`() {
     val vec = Vec1(4.2)
-    val mutableVec = vec.toMutableVec1()
+    val mutableVec = vec.toMutable()
     mutableVec.x shouldBe 4.2
   }
 
   @Test
-  fun `toVec1 on Vec1 returns itself`() {
+  fun `toImmutable on Vec1 returns itself`() {
     val vec = Vec1(5.3)
-    val result = vec.toVec1()
+    val result = vec.toImmutable()
     result shouldBe vec
+    (result === vec) shouldBe true
   }
 
   @Test

--- a/src/commonTest/kotlin/io/github/cponfick/kompgeom/euclidean/threed/MutableVec3Test.kt
+++ b/src/commonTest/kotlin/io/github/cponfick/kompgeom/euclidean/threed/MutableVec3Test.kt
@@ -1,6 +1,8 @@
 package io.github.cponfick.kompgeom.euclidean.threed
 
 import io.github.cponfick.kompgeom.core.AngleUnit
+import io.github.cponfick.kompgeom.core.toImmutable
+import io.github.cponfick.kompgeom.core.toMutable
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlin.math.PI
@@ -307,16 +309,16 @@ class MutableVec3Test {
   }
 
   @Test
-  fun `toVec3 creates a identical copy of the vector`() {
+  fun `toImmutable creates an immutable copy of the vector`() {
     val original = MutableVec3(7.0, 8.0, 9.0)
-    val copy = original.toVec3()
+    val copy = original.toImmutable()
     original.eq(copy)
   }
 
   @Test
-  fun `toMutableVec3 creates a mutable copy of the vector`() {
+  fun `toMutable creates a mutable copy of the vector`() {
     val original = MutableVec3(7.0, 8.0, 9.0)
-    val mutableCopy = original.toMutableVec3()
+    val mutableCopy = original.toMutable()
     mutableCopy.eq(original)
     (mutableCopy === original) shouldBe false
   }

--- a/src/commonTest/kotlin/io/github/cponfick/kompgeom/euclidean/threed/Vec3Test.kt
+++ b/src/commonTest/kotlin/io/github/cponfick/kompgeom/euclidean/threed/Vec3Test.kt
@@ -1,6 +1,8 @@
 package io.github.cponfick.kompgeom.euclidean.threed
 
 import io.github.cponfick.kompgeom.core.AngleUnit
+import io.github.cponfick.kompgeom.core.toImmutable
+import io.github.cponfick.kompgeom.core.toMutable
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlin.math.PI
@@ -312,17 +314,17 @@ class Vec3Test {
   }
 
   @Test
-  fun `toVec3 creates a identical copy of the vector`() {
+  fun `toImmutable on Vec3 returns itself`() {
     val original = Vec3(7.0, 8.0, 9.0)
-    val copy = original.toVec3()
+    val copy = original.toImmutable()
     copy shouldBe original
-    (copy === original) shouldBe false
+    (copy === original) shouldBe true
   }
 
   @Test
-  fun `toMutableVec3 creates a mutable copy of the vector`() {
+  fun `toMutable creates a mutable copy of the vector`() {
     val original = Vec3(7.0, 8.0, 9.0)
-    val mutableCopy = original.toMutableVec3()
+    val mutableCopy = original.toMutable()
     original.eq(mutableCopy)
   }
 

--- a/src/commonTest/kotlin/io/github/cponfick/kompgeom/euclidean/twod/MutableVec2Test.kt
+++ b/src/commonTest/kotlin/io/github/cponfick/kompgeom/euclidean/twod/MutableVec2Test.kt
@@ -1,6 +1,8 @@
 package io.github.cponfick.kompgeom.euclidean.twod
 
 import io.github.cponfick.kompgeom.core.AngleUnit
+import io.github.cponfick.kompgeom.core.toImmutable
+import io.github.cponfick.kompgeom.core.toMutable
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlin.math.PI
@@ -301,16 +303,16 @@ class MutableVec2Test {
   }
 
   @Test
-  fun `toVec2 creates a identical copy of the vector`() {
+  fun `toImmutable creates an immutable copy of the vector`() {
     val original = MutableVec2(7.0, 8.0)
-    val copy = original.toVec2()
+    val copy = original.toImmutable()
     original.eq(copy)
   }
 
   @Test
-  fun `toMutableVec2 creates a mutable copy of the vector`() {
+  fun `toMutable creates a mutable copy of the vector`() {
     val original = MutableVec2(7.0, 8.0)
-    val mutableCopy = original.toMutableVec2()
+    val mutableCopy = original.toMutable()
     mutableCopy.eq(original) shouldBe true
     (mutableCopy === original) shouldBe false
   }

--- a/src/commonTest/kotlin/io/github/cponfick/kompgeom/euclidean/twod/Vec2Test.kt
+++ b/src/commonTest/kotlin/io/github/cponfick/kompgeom/euclidean/twod/Vec2Test.kt
@@ -1,6 +1,8 @@
 package io.github.cponfick.kompgeom.euclidean.twod
 
 import io.github.cponfick.kompgeom.core.AngleUnit
+import io.github.cponfick.kompgeom.core.toImmutable
+import io.github.cponfick.kompgeom.core.toMutable
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import kotlin.math.PI
@@ -296,17 +298,17 @@ class Vec2Test {
   }
 
   @Test
-  fun `toVec3 creates a identical copy of the vector`() {
+  fun `toImmutable on Vec2 returns itself`() {
     val original = Vec2(7.0, 8.0)
-    val copy = original.toVec2()
+    val copy = original.toImmutable()
     copy shouldBe original
-    (copy === original) shouldBe false
+    (copy === original) shouldBe true
   }
 
   @Test
-  fun `toMutableVec2 creates a mutable copy of the vector`() {
+  fun `toMutable creates a mutable copy of the vector`() {
     val original = Vec2(7.0, 8.0)
-    val mutableCopy = original.toMutableVec2()
+    val mutableCopy = original.toMutable()
     original.eq(mutableCopy)
   }
 


### PR DESCRIPTION
## Summary
- Add polymorphic `toImmutable()` and `toMutable()` extension functions on `Vector1`, `Vector2`, and `Vector3` interfaces in a new `VectorExtensions.kt` file in the `core` package
- `toImmutable()` returns the same instance when already immutable (via `when` type check), avoiding unnecessary copies
- `toMutable()` always creates a new instance, consistent with Kotlin stdlib conventions (`toMutableList()`)
- Remove the old concrete type-specific methods (`toVec1`/`toMutableVec1`, `toVec2`/`toMutableVec2`, `toVec3`/`toMutableVec3`) from all 6 vector classes
- Update all internal usages and tests

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)